### PR TITLE
fixes #23: Now compatible with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,8 +44,11 @@
 Registration Plugin Changelog
 </h1>
 
-<p><b>1.8.1</b> -- To Be Determined</p>
+<p><b>1.9.0</b> -- To Be Determined</p>
 <ul>
+    <li>Now requires Openfire 4.4.0</li>
+    <li>Minimum Java requirement: 11</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-registration-plugin/issues/23'>#23</a>] - Compatible with Openfire 5.0.0.</li>
 </ul>
 
 <p><b>1.8.0</b> -- November 21, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,9 +6,9 @@
     <description>Performs various actions whenever a new user account is created.</description>
     <author>Ryan Graham</author>
     <version>${project.version}</version>
-    <date>2023-11-21</date>
-    <minServerVersion>4.0.0</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2025-06-20</date>
+    <minServerVersion>4.4.0</minServerVersion>
+    <minJavaVersion>11</minJavaVersion>
 
     <adminconsole>
         <tab id="tab-users">

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.4.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>registration</artifactId>
     <name>Registration Plugin</name>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
 
     <build>
         <sourceDirectory>src/java</sourceDirectory>

--- a/src/web/registration-props-form.jsp
+++ b/src/web/registration-props-form.jsp
@@ -1,5 +1,5 @@
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@
     String privacyList = ParamUtils.getParameter(request, "privacylist");
     String privacyListName = ParamUtils.getParameter(request, "privacylistname");
     
-    RegistrationPlugin plugin = (RegistrationPlugin) XMPPServer.getInstance().getPluginManager().getPlugin("registration");
+    RegistrationPlugin plugin = (RegistrationPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("Registration").orElseThrow();
 
     Map<String, String> errors = new HashMap<String, String>();
     if (addIM) {

--- a/src/web/sign-up.jsp
+++ b/src/web/sign-up.jsp
@@ -1,5 +1,5 @@
 <%--
-  - Copyright (C) 2005-2008 Jive Software. All rights reserved.
+  - Copyright (C) 2005-2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@
     String passwordConfirm = ParamUtils.getParameter(request,"passwordConfirm");
     String recaptchaResponse = ParamUtils.getParameter(request,"g-recaptcha-response");
 
-    RegistrationPlugin plugin = (RegistrationPlugin) webManager.getXMPPServer().getPluginManager().getPlugin("registration");
+    RegistrationPlugin plugin = (RegistrationPlugin) webManager.getXMPPServer().getPluginManager().getPluginByName("Registration").orElseThrow();
 
     // Handle a request to create a user:
     if (create) {


### PR DESCRIPTION
This removes the usage of API dropped in Openfire 5.0.0. The minimum server requirement is now Openfire 4.4.0 (and Java 10).