### PR TITLE
Update minimum version of Openfire to 5.2.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,12 @@
 Registration Plugin Changelog
 </h1>
 
+<p><b>2.0.0</b> -- (to be determined)</p>
+<ul>
+    <li>Now requires Openfire 5.2.0</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-registration-plugin/issues/28'>#28</a>] - Fix: NoSuchMethodError: org.jivesoftware.util.JiveGlobals.deleteProperty</li>
+</ul>
+
 <p><b>1.9.0</b> -- June 20, 2025</p>
 <ul>
     <li>Now requires Openfire 4.4.0</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,8 +7,7 @@
     <author>Ryan Graham</author>
     <version>${project.version}</version>
     <date>2025-06-20</date>
-    <minServerVersion>4.4.0</minServerVersion>
-    <minJavaVersion>11</minJavaVersion>
+    <minServerVersion>5.2.0</minServerVersion>
 
     <adminconsole>
         <tab id="tab-users">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.4.0</version>
+        <version>5.2.0-SNAPSHOT</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>registration</artifactId>


### PR DESCRIPTION
This pulls in an API change related to OF-3313 that makes earlier versions of this plugin incompatible with Openfire 5.2.0 and later.

Note that this commit declares a dependency on Openfire 5.2.0-SNAPSHOT. This is not a stable build, but one is not yet available for 5.2.0. As soon as there is, it should be used.

fixes #28